### PR TITLE
Added | Event | AppDevCon

### DIFF
--- a/Events/26-AppDevCon.json
+++ b/Events/26-AppDevCon.json
@@ -1,0 +1,13 @@
+{
+    "name": "AppDevCon",
+    "url": "https://appdevcon.nl",
+    "logo": "https://pbs.twimg.com/profile_images/1133660687383900160/5_0gzXbh_reasonably_small.png",
+    "startDate": "2020-03-10T12:00:00+0000",
+    "endDate": "2020-03-13T12:00:00+0000",
+    "country": "The Netherlands",
+    "city": "Amsterdam",
+    "tags": [
+      "tickets",
+      "callForPapers"
+    ]
+}

--- a/Events/26-AppDevCon.json
+++ b/Events/26-AppDevCon.json
@@ -1,10 +1,10 @@
 {
     "name": "AppDevCon",
     "url": "https://appdevcon.nl",
-    "logo": "https://pbs.twimg.com/profile_images/1133660687383900160/5_0gzXbh_reasonably_small.png",
+    "logo": "https://firebasestorage.googleapis.com/v0/b/pedrommcarrasco-cocoahub.appspot.com/o/events%2FappDevCon.png?alt=media&token=904de15e-8b6d-4522-ba76-c211bb65efd2",
     "startDate": "2020-03-10T12:00:00+0000",
     "endDate": "2020-03-13T12:00:00+0000",
-    "country": "The Netherlands",
+    "country": "Netherlands",
     "city": "Amsterdam",
     "tags": [
       "tickets",

--- a/Events/26-AppDevCon.json
+++ b/Events/26-AppDevCon.json
@@ -4,7 +4,7 @@
     "logo": "https://firebasestorage.googleapis.com/v0/b/pedrommcarrasco-cocoahub.appspot.com/o/events%2FappDevCon.png?alt=media&token=904de15e-8b6d-4522-ba76-c211bb65efd2",
     "startDate": "2020-03-10T12:00:00+0000",
     "endDate": "2020-03-13T12:00:00+0000",
-    "country": "Netherlands",
+    "country": "The Netherlands",
     "city": "Amsterdam",
     "tags": [
       "tickets",


### PR DESCRIPTION
This adds AppDevCon, a conference in The Netherlands. 

_Note:_ Lack of a public square icon points this to an icon on Twitter instead.